### PR TITLE
This plugin must be callable by other plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# From: https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
+!.gitignore
+*~
+
+# From: https://github.com/github/gitignore/blob/master/Global/Windows.gitignore
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# From https://github.com/github/gitignore/blob/master/Global/OSX.gitignore
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+# From https://github.com/github/gitignore/blob/master/Perl.gitignore
+blib/
+.build/
+_build/
+cover_db/
+inc/
+Build
+!Build/
+Build.bat
+.last_cover_stats
+Makefile
+Makefile.old
+MANIFEST.bak
+META.yml
+MYMETA.yml
+MYMETA.json
+nytprof.out
+pm_to_blib

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Dancer2-Plugin-DBIC
 
+0.0009	2015-03-22
+	This plugin must be callable from other plugins
+
 0.0005  2013-10-29
         Fixed tests again. Dancer2 removed the :tests import option.
         Thanks ennio (https://github.com/scriplit).

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,7 @@ my %WriteMakefileArgs = (
   "NAME" => "Dancer2::Plugin::DBIC",
   "PREREQ_PM" => {
     "DBIx::Class" => 0,
-    "Dancer2" => "0.153002",
+    "Dancer2" => "0.159002",
     "Module::Load" => 0
   },
   "TEST_REQUIRES" => {
@@ -39,7 +39,7 @@ my %WriteMakefileArgs = (
 
 my %FallbackPrereqs = (
   "DBIx::Class" => 0,
-  "Dancer2" => "0.153002",
+  "Dancer2" => "0.159002",
   "File::Spec" => 0,
   "IO::Handle" => 0,
   "IPC::Open3" => 0,

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name             = Dancer2-Plugin-DBIC
 author           = Naveed Massjouni <naveedm9@gmail.com>
 license          = Perl_5
 copyright_year   = 2013
-version          = 0.0008
+version          = 0.0009
 
 [@Filter]
 -bundle = @Basic
@@ -29,7 +29,7 @@ repository.web = https://github.com/ironcamel/Dancer2-Plugin-DBIC
 [PodWeaver]
 
 [Prereqs]
-Dancer2      = 0.153002
+Dancer2      = 0.159002
 DBIx::Class  = 0
 Module::Load = 0
 

--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -8,15 +8,11 @@ use utf8;
 use Dancer2::Plugin;
 use Module::Load;
 
-my $cfg = {};
 my $schemas = {};
-
-on_plugin_import {
-    $cfg = plugin_setting;
-};
 
 sub schema {
     my ($dsl, $name) = @_;
+    my $cfg = plugin_setting($dsl);
 
     if (not defined $name) {
         if (keys %$cfg == 1) {

--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -5,14 +5,17 @@ package Dancer2::Plugin::DBIC;
 use strict;
 use warnings;
 use utf8;
-use Dancer2::Plugin qw(:no_dsl);
-use Module::Load;
+use Dancer2::Plugin;
 
+my $cfg = {};
 my $schemas = {};
+
+on_plugin_import {
+    $cfg = plugin_setting;
+};
 
 sub schema {
     my ($dsl, $name) = @_;
-    my $cfg = plugin_setting;
 
     if (not defined $name) {
         if (keys %$cfg == 1) {

--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use utf8;
 use Dancer2::Plugin;
-use Module::Load
+use Module::Load;
 
 my $cfg = {};
 my $schemas = {};

--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 use utf8;
 use Dancer2::Plugin;
+use Module::Load
 
 my $cfg = {};
 my $schemas = {};

--- a/t/001_basics.t
+++ b/t/001_basics.t
@@ -1,0 +1,6 @@
+use Test::More tests => 1;
+
+use strict;
+use warnings;
+
+use_ok 'Dancer2::Plugin::DBIC';


### PR DESCRIPTION
It's about calling plugin_setting with the right $dsl
to prevent "DEPRECATED: $plugin calls 'dsl' instead of '\$dsl->dsl'."

This patch works with older Dancer2's.

Next is a patch to Dancer2::Plugin.pm to effectuate the use.
