### PR TITLE
suppress " DEPRECATED: Dancer2::Plugin::DBIC calls 'dsl' instead of '…

### DIFF
--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -5,7 +5,7 @@ package Dancer2::Plugin::DBIC;
 use strict;
 use warnings;
 use utf8;
-use Dancer2::Plugin;
+use Dancer2::Plugin qw/:no_dsl/;
 use DBICx::Sugar;
 
 sub _schema {


### PR DESCRIPTION

suppress " DEPRECATED: Dancer2::Plugin::DBIC calls 'dsl' instead of '->dsl'. " messages, they are drowning legitimate and interesting warnings