### PR TITLE
Remove subroutine import list from test 04

### DIFF
--- a/t/lib/TestApp.pm
+++ b/t/lib/TestApp.pm
@@ -1,7 +1,7 @@
 package t::lib::TestApp;
 
 use Dancer2;
-use Dancer2::Plugin::DBIC qw(schema resultset);
+use Dancer2::Plugin::DBIC;
 
 get '/' => sub {
     my $total_user = schema->resultset('User')->search();


### PR DESCRIPTION
The new (soon to be released) Dancer2::Plugin code no longer allows
subroutine import list to be supplied when plugin is used.