### PR TITLE
use $dsl->config instead of plugin_settings for plugin2

### DIFF
--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -10,7 +10,16 @@ use DBICx::Sugar;
 
 sub _schema {
     my ($dsl, $name) = @_;
-    DBICx::Sugar::config( plugin_setting );
+    my $config;
+    # ugly switch needed to support plugin2 plugins which use this plugin
+    # whilst still working for plugin1
+    if ( $dsl->can('with_plugin') ) {
+        $config = $dsl->config;
+    }
+    else {
+        $config = plugin_setting;
+    }
+    DBICx::Sugar::config( $config );
     return DBICx::Sugar::schema($name);
 };
 

--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -13,7 +13,7 @@ sub _schema {
     my $config;
     # ugly switch needed to support plugin2 plugins which use this plugin
     # whilst still working for plugin1
-    if ( $dsl->can('with_plugin') ) {
+    if ( $dsl->app->can('with_plugin') ) {
         $config = $dsl->config;
     }
     else {


### PR DESCRIPTION
Any plugins which use this plugin will not work when plugin1's
plugin_config keyword is used and so if we smell plugin2 we get config
via $dsl->config instead. This is needed by
Dancer2::Plugin::Auth::Extensible::Provider::DBIC (and probably some
other plugins - still some work to do).

Thanks to yanick for the pointer.