### PR TITLE
Schema with config

### DIFF
--- a/lib/Dancer2/Plugin/DBIC.pm
+++ b/lib/Dancer2/Plugin/DBIC.pm
@@ -9,7 +9,7 @@ use Dancer2::Plugin;
 use DBICx::Sugar;
 
 sub _schema {
-    my ($dsl, $name) = @_;
+    my ($dsl, $name, $cfg) = @_;
     my $config;
     # ugly switch needed to support plugin2 plugins which use this plugin
     # whilst still working for plugin1
@@ -20,7 +20,7 @@ sub _schema {
         $config = plugin_setting;
     }
     DBICx::Sugar::config( $config );
-    return DBICx::Sugar::schema($name);
+    return DBICx::Sugar::schema($name, $cfg);
 }
 
 sub _rset {


### PR DESCRIPTION
[This is my last entry for the CPAN PR Challenge.]

You can consider this "Step 4 out of 4" in my series. :)

I have added an ability to call the `schema` keyword with a specific configuration. This simply passes on that configuration option to `DBICx-Sugar`, which - if [this] will be merged - allow handling [issue #12](https://github.com/ironcamel/Dancer2-Plugin-DBIC/issues/12).

It also includes a test proving it correct.